### PR TITLE
MAINT: update instrument test class

### DIFF
--- a/pysatCDAAC/tests/test_instruments.py
+++ b/pysatCDAAC/tests/test_instruments.py
@@ -9,8 +9,8 @@ from pysat.tests.instrument_test_class import InstTestClass
 # Developers for instrument libraries should update the following line to
 # point to their own library package
 # e.g.,
-# instruments = generate_instrument_list(package=mypackage.instruments)
-instruments = generate_instrument_list(package=pysatCDAAC.instruments)
+# instruments = generate_instrument_list(inst_loc=mypackage.instruments)
+instruments = generate_instrument_list(inst_loc=pysatCDAAC.instruments)
 
 # The following lines apply the custom instrument lists to each type of test
 method_list = [func for func in dir(InstTestClass)
@@ -24,13 +24,14 @@ for method in method_list:
                  for j in range(0, Nargs)]
         # Add instruments from your library
         if 'all_inst' in names:
-            mark = pytest.mark.parametrize("name", instruments['names'])
+            mark = pytest.mark.parametrize("inst_name", instruments['names'])
             getattr(InstTestClass, method).pytestmark.append(mark)
         elif 'download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['download'])
+            mark = pytest.mark.parametrize("inst_dict", instruments['download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
         elif 'no_download' in names:
-            mark = pytest.mark.parametrize("inst", instruments['no_download'])
+            mark = pytest.mark.parametrize("inst_dict",
+                                           instruments['no_download'])
             getattr(InstTestClass, method).pytestmark.append(mark)
 
 
@@ -40,9 +41,9 @@ class TestInstruments(InstTestClass):
         """Runs before every method to create a clean testing setup."""
         # Developers for instrument libraries should update the following line
         # to point to their own library package, e.g.,
-        # self.package = mypackage.instruments
-        self.package = pysatCDAAC.instruments
+        # self.inst_loc = mypackage.instruments
+        self.inst_loc = pysatCDAAC.instruments
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.package
+        del self.inst_loc

--- a/pysatCDAAC/tests/test_instruments.py
+++ b/pysatCDAAC/tests/test_instruments.py
@@ -1,10 +1,14 @@
+import tempfile
+
 import pytest
 
+import pysat
 # Make sure to import your instrument library here
 import pysatCDAAC
 # Import the test classes from pysat
-from pysat.tests.instrument_test_class import generate_instrument_list
+from pysat.utils import generate_instrument_list
 from pysat.tests.instrument_test_class import InstTestClass
+
 
 # Developers for instrument libraries should update the following line to
 # point to their own library package
@@ -37,13 +41,26 @@ for method in method_list:
 
 class TestInstruments(InstTestClass):
 
-    def setup(self):
-        """Runs before every method to create a clean testing setup."""
+    def setup_class(self):
+        """Runs once before the tests to initialize the testing setup."""
+        # Make sure to use a temporary directory so that the user's setup is not
+        # altered
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.saved_path = pysat.data_dir
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
         # Developers for instrument libraries should update the following line
-        # to point to their own library package, e.g.,
+        # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysatCDAAC.instruments
 
-    def teardown(self):
+    def teardown_class(self):
         """Runs after every method to clean up previous testing."""
-        del self.inst_loc
+        pysat.utils.set_data_dir(self.saved_path, store=False)
+        self.tempdir.cleanup()
+        del self.inst_loc, self.saved_path, self.tempdir
+
+    def setup_method(self):
+        """Runs before every method to create a clean testing setup."""
+
+    def teardown_method(self):
+        """Runs after every method to clean up previous testing."""


### PR DESCRIPTION
Updates syntax for instrument tests inherited from `pysat` as part of pysat/pysat#552.
- End-to-end instrument tests now iterate over a list of `dict` objects containing info to create an instrument
- `pytest.mark` statements updated accordingly
- `package` renamed as `inst_loc`

Currently failing on Travis since these updates are not in `pysat` develop-3, but passes locally when using the tst/inst_test_class_update branch of `pysat`.