### PR TITLE
BUG: non-unique cosmic files

### DIFF
--- a/pysatCDAAC/instruments/cosmic_gps.py
+++ b/pysatCDAAC/instruments/cosmic_gps.py
@@ -164,7 +164,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         # due to multiple spacecraft and antennas
         # this ensures that we can make the times all unique for the file list
         idx = np.argsort(uts)
-        # adding linearly increasing offsets less than 0.01 s
+        # adding linearly increasing offsets less than 0.0001 s
         shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-7 + 1.E-7
         uts[idx] += shift_uts
 

--- a/pysatCDAAC/instruments/cosmic_gps.py
+++ b/pysatCDAAC/instruments/cosmic_gps.py
@@ -165,7 +165,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         # this ensures that we can make the times all unique for the file list
         idx = np.argsort(uts)
         # adding linearly increasing offsets less than 0.01 s
-        shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-5 + 1.E-5
+        shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-7 + 1.E-7
         uts[idx] += shift_uts
 
         index = pysat.utils.time.create_datetime_index(year=year,

--- a/pysatCDAAC/instruments/cosmic_gps.py
+++ b/pysatCDAAC/instruments/cosmic_gps.py
@@ -164,8 +164,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         # due to multiple spacecraft and antennas
         # this ensures that we can make the times all unique for the file list
         idx = np.argsort(uts)
-        # adding linearly increasing offsets less than 0.0001 s
-        shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-7 + 1.E-7
+        # adding linearly increasing offsets less than 0.01 s
+        shift_uts = np.mod(np.arange(len(year)), 1E4) * 1.E-6 + 1.E-6
         uts[idx] += shift_uts
 
         index = pysat.utils.time.create_datetime_index(year=year,


### PR DESCRIPTION
Addresses #2.

The `scnlv1` files were generating a "non-unique" file error when attempting to load the object.  This was only occurring locally on one system where I've downloaded ~2 years of scintillation data, which translates to ~2e5 files.  The code previously added a fudge factor of up to 0.01 s to the index datetime stamps to keep times unique.  Presumably this becomes an issue again once the volume of files hits a critical mass.  This reduces the fudge factor to less than 0.0001 s to stave off this problem.  There's probably a more robust way of dealing with this.