### PR TITLE
BUG: Fixed errant sat_id->inst_id. Altered COSMIC file times.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Create conda test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 pytest-cov pytest-ordering future
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas portalocker xarray requests beautifulsoup4 lxml netCDF4 pytest-cov pytest-ordering future
   - conda activate test-environment
   # Get latest coveralls from pip, not conda
   - pip install coveralls

--- a/pysatCDAAC/instruments/cosmic_gps.py
+++ b/pysatCDAAC/instruments/cosmic_gps.py
@@ -164,8 +164,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
         # due to multiple spacecraft and antennas
         # this ensures that we can make the times all unique for the file list
         idx = np.argsort(uts)
-        # adding linearly increasing offsets less than 0.01 s
-        shift_uts = np.mod(np.arange(len(year)), 1E4) * 1.E-6 + 1.E-6
+        # adding linearly increasing offsets less than 0.1 s
+        shift_uts = np.mod(np.arange(len(year)), 9E4) * 1.E-5 + 1.E-5
         uts[idx] += shift_uts
 
         index = pysat.utils.time.create_datetime_index(year=year,
@@ -230,7 +230,7 @@ def load(fnames, tag=None, inst_id=None, altitude_bin=None):
             # get cosmic satellite ID
             c_id = np.array([snip[3] for snip in output.fileStamp]).astype(int)
             # time offset
-            utsec += output.occulting_inst_id*1.e-5 + c_id*1.e-6
+            utsec += output.occulting_sat_id*1.e-5 + c_id*1.e-6
         else:
             # construct time out of three different parameters
             # duration must be less than 10,000
@@ -487,6 +487,8 @@ def download(date_array, tag, inst_id, data_path=None,
         # Try re-processed data (preferred)
         auth = requests.auth.HTTPBasicAuth(user, password)
         try:
+            # TODO: Update downloads to this new address
+            #'https://data.cosmic.ucar.edu/gnss-ro/cosmic1/repro2013/level2/2008/001/'
             dwnld = ''.join(("https://cdaac-www.cosmic.ucar.edu/cdaac/rest/",
                              "tarservice/data/cosmic2013/"))
             dwnld = dwnld + sub_dir + '/{year:04d}.{doy:03d}'.format(year=yr,

--- a/pysatCDAAC/instruments/cosmic_gps.py
+++ b/pysatCDAAC/instruments/cosmic_gps.py
@@ -487,8 +487,6 @@ def download(date_array, tag, inst_id, data_path=None,
         # Try re-processed data (preferred)
         auth = requests.auth.HTTPBasicAuth(user, password)
         try:
-            # TODO: Update downloads to this new address
-            #'https://data.cosmic.ucar.edu/gnss-ro/cosmic1/repro2013/level2/2008/001/'
             dwnld = ''.join(("https://cdaac-www.cosmic.ucar.edu/cdaac/rest/",
                              "tarservice/data/cosmic2013/"))
             dwnld = dwnld + sub_dir + '/{year:04d}.{doy:03d}'.format(year=yr,

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,6 +41,7 @@ long_description_content_type = text/markdown
     numpy
     pandas
     xarray
+    portalocker
     pysat
 
 [coverage:report]


### PR DESCRIPTION
Started on meta but found a time issue instead. Looks like the meta is handled over in #11.

The times created by pysat would be unique, but when written to an internal .pysat file, the resolution was insufficient to maintain a unique file list. So unless the file list was updated each time a cosmic_gps Instrument was instantiated, a few files would get removed.
