### PR TITLE
MAINT: nep29 2022 + testing standards + pysat RC test

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,9 +16,9 @@ jobs:
 
     name:
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,32 +12,32 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
         numpy_ver: [latest]
         include:
-          - python-version: "3.7"
-            numpy_ver: "1.18"
+          - python-version: "3.8"
+            numpy_ver: "1.20"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: |
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Install standard dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
         pip install -r test_requirements.txt
-
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.numpy_ver != 'latest'}}
-      run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,13 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: ["ubuntu-latest", "windows-latest"]
         python-version: ["3.9", "3.10"]
-        numpy_ver: [latest]
+        numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
             numpy_ver: "1.20"
-            os: ubuntu-latest
+            os: "ubuntu-latest"
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.9", "3.10"]
         numpy_ver: ["latest"]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,8 @@ jobs:
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+        # Need to force install of pandas compliant with NEP29
+        pip install "pandas<1.5"
 
     - name: Install standard dependencies
       run: |

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -3,7 +3,7 @@
 
 name: Test with latest pysat RC
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ["3.10"]
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -1,0 +1,44 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test with latest pysat RC
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.10"]
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install pysat RC
+      run: pip install --no-deps -i https://test.pypi.org/simple/ pysat
+
+    - name: Install standard dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install -r test_requirements.txt
+
+    - name: Set up pysat
+      run: |
+        mkdir pysatData
+        python -c "import pysat; pysat.params['data_dirs'] = 'pysatData'"
+
+    - name: Test with pytest
+      run: pytest -vs --cov=pysatCDAAC/
+
+    - name: Publish results to coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: coveralls --rcfile=setup.cfg --service=github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Update links in documentation
   * Update testing compliance
   * Add windows testing
+  * Add workflow for testing with pysat RC
 
 ## [0.0.2] - 2021-06-18
 * Update instrument style for pysat 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   as a variable.
 * Added `download` to general methods
 * Update links in documentation
+* Update testing compliance
 
 ## [0.0.2] - 2021-06-18
 * Update instrument style for pysat 3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Added altitude binning profile support for all datasets with altitude
   as a variable.
 * Added `download` to general methods
-* Update links in documentation
-* Update testing compliance
+* Maintenance
+  * Update links in documentation
+  * Update testing compliance
+  * Add windows testing
 
 ## [0.0.2] - 2021-06-18
 * Update instrument style for pysat 3.0.0

--- a/pysatCDAAC/tests/test_instruments.py
+++ b/pysatCDAAC/tests/test_instruments.py
@@ -8,71 +8,31 @@ Imports test methods from pysat.tests.instrument_test_class
 
 import numpy as np
 import pytest
-import tempfile
 
 import pysat
 # Import the test classes from pysat
-from pysat.tests.instrument_test_class import InstTestClass
-from pysat.utils import generate_instrument_list
+from pysat.tests.classes import cls_instrument_library as clslib
 
 # Make sure to import your instrument library here
 import pysatCDAAC
 
 
 # Retrieve the lists of CDAAC instruments and testing methods
-instruments = generate_instrument_list(inst_loc=pysatCDAAC.instruments)
-
-method_list = [func for func in dir(InstTestClass)
-               if callable(getattr(InstTestClass, func))]
-
-# Search tests for iteration via pytestmark, update instrument list
-for method in method_list:
-    if hasattr(getattr(InstTestClass, method), 'pytestmark'):
-        # Get list of names of pytestmarks
-        Nargs = len(getattr(InstTestClass, method).pytestmark)
-        names = [getattr(InstTestClass, method).pytestmark[j].name
-                 for j in range(0, Nargs)]
-        # Add instruments from your library
-        if 'all_inst' in names:
-            mark = pytest.mark.parametrize("inst_name", instruments['names'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'download' in names:
-            mark = pytest.mark.parametrize("inst_dict", instruments['download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
-        elif 'no_download' in names:
-            mark = pytest.mark.parametrize("inst_dict",
-                                           instruments['no_download'])
-            getattr(InstTestClass, method).pytestmark.append(mark)
+instruments = clslib.InstLibTests.initialize_test_package(
+    clslib.InstLibTests, inst_loc=pysatCDAAC.instruments)
 
 
-class TestInstruments(InstTestClass):
+class TestInstruments(clslib.InstLibTests):
     """Main class for instrument tests.
 
     Note
     ----
-    Uses class level setup and teardown so that all tests use the same
-    temporary directory. We do not want to geneate a new tempdir for each test,
-    as the load tests need to be the same as the download tests.
+    All standard tests, setup, and teardown inherited from the core pysat
+    instrument test class.
 
     """
 
-    def setup_class(self):
-        """Initialize the testing setup once before all tests are run."""
-        # Make sure to use a temporary directory so that the user's setup is not
-        # altered
-        self.tempdir = tempfile.TemporaryDirectory()
-        self.saved_path = pysat.params['data_dirs']
-        pysat.params.data['data_dirs'] = [self.tempdir.name]
-
-        # Assign the location of the Instrument sub-modules
-        self.inst_loc = pysatCDAAC.instruments
-
-    def teardown_class(self):
-        """Clean up downloaded files and parameters from tests."""
-        pysat.params.data['data_dirs'] = self.saved_path
-        self.tempdir.cleanup()
-        del self.inst_loc, self.saved_path, self.tempdir
-
+    @pytest.mark.second
     @pytest.mark.parametrize("inst_dict", [x for x in instruments['download']])
     @pytest.mark.parametrize("bin_num", [100, 200])
     def test_altitude_bin_keyword(self, inst_dict, bin_num):

--- a/pysatCDAAC/tests/test_instruments.py
+++ b/pysatCDAAC/tests/test_instruments.py
@@ -58,7 +58,7 @@ class TestInstruments(clslib.InstLibTests):
                                           altitude_bin_num=bin_num)
         date = inst_dict['inst_module']._test_dates[inst_dict['inst_id']]
         date = date[inst_dict['tag']]
-        self.test_inst.load(date=date)
+        self.test_inst.load(date=date, use_header=True)
 
         # Confirm presence of binned altitudes.
         assert 'MSL_bin_alt' in self.test_inst.data

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,7 @@ ignore =
 markers =
     all_inst: tests all instruments
     download: tests for downloadable instruments
+    load_options: tests for instruments with additional options
     no_download: tests for instruments without download support
     first: first tests to run
     second: second tests to run


### PR DESCRIPTION
# Description

Addresses pysat/pysat#1042 and pysat/pysat#1048

Updates to use released pysat test syntax and latest standard for NEP29 and github actions.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via pytest

Inspection of logs at https://github.com/pysat/pysatCDAAC/actions/runs/3439721561 to confirm that pysat is only installed via the RC.

**Test Configuration**:
* Operating system: Mac OS X Monterrey
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
