### PR TITLE
BUG: fix metadata in cosmic gps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.X] - 2023-XX-XX
+* Bug fixes
+  * Update metadata transfer for cosmic gps
+
 ## [0.0.3] - 2022-12-12
 * Updated `cosmic_gps` to support xarray Datasets
 * Added altitude binning profile support for all datasets with altitude


### PR DESCRIPTION
# Description

Addresses #36

Some of the metadata values for cosmic gps are not being set correctly.  In part this is because
- Not all variables have units in the metadata
- The altitude bin variable is created by pysat without metadata
- Scintillation data renames time as profile_time for pysat compliance

The fixes implemented here:
- Scan for the core metadata that may exist (units, long name, fill value) and extract the ones that exist
- Copy the altitude metadata for the new altitude bin parameter
- Making sure time metadata is copied to profile_time

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running pytest and check for metadata warnings.

Loading select datasets and inspecting the loaded metadata.
- `ionprf` data with altitude binning
- `atmprf` data
- `scnlvl1` data

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
