### PR TITLE
BUG/MAINT: update standards for Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,10 +30,7 @@ jobs:
 
     - name: Install NEP29 dependencies
       if: ${{ matrix.numpy_ver != 'latest'}}
-      run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
-        # Need to force install of pandas compliant with NEP29
-        pip install "pandas<1.5"
+      run: pip install --no-cache-dir numpy==${{ matrix.numpy_ver }}
 
     - name: Install standard dependencies
       run: |

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [push]
+on: [workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -4,7 +4,7 @@
 
 name: Test install of latest RC from pip
 
-on: [workflow_dispatch]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -1,0 +1,30 @@
+# This workflow will install Python dependencies and the latest RC of pysatNASA from test pypi.
+# This test should be manually run before a pysatNASA RC is officially approved and versioned.
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Test install of latest RC from pip
+
+on: [workflow_dispatch]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.10"]  # Keep this version at the highest supported Python version
+
+    name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install standard dependencies
+      run: pip install -r requirements.txt
+
+    - name: Install pysatCDAAC RC
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysatCDAAC

--- a/.github/workflows/pysat_rc.yml
+++ b/.github/workflows/pysat_rc.yml
@@ -23,7 +23,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pysat RC
-      run: pip install --no-deps -i https://test.pypi.org/simple/ pysat
+      run: pip install --no-deps --pre -i https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ pysat
 
     - name: Install standard dependencies
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [0.0.X] - 2023-XX-XX
 * Bug fixes
   * Update metadata transfer for cosmic gps
+* Maintenance
+  * Update Github Actions standards
 
 ## [0.0.3] - 2022-12-12
 * Updated `cosmic_gps` to support xarray Datasets


### PR DESCRIPTION
# Description

Updates several bugs in the RC testing due to new behaviour at Github Actions.

- `--no_binary` is removed in latest pip
- Use `--pre` for pip to include pre-release versions at test pypi
- Use `--extra-index-url` to support wheel builds
- Adds test for installed the RC from test pypi

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

At Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
