### PR TITLE
MAINT: Update deprecated 'Dataset.dims' usage to 'Dataset.sizes'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Maintenance
   * Update GitHub Actions standards
   * Add compatibility for numpy version>=3.2.0
+  * Update usage of 'Dataset.dims' to 'Dataset.sizes'
 
 ## [0.0.4] - 2023-08-11
 * Bug fixes

--- a/pysatCDAAC/tests/test_instruments.py
+++ b/pysatCDAAC/tests/test_instruments.py
@@ -70,6 +70,6 @@ class TestInstruments(clslib.InstLibTests):
         assert len(idx) + len(idx2) == np.prod(rem.shape)
 
         # Confirm length of each profile corresponds to bin_num
-        assert self.test_inst.data.dims['RO'] == bin_num
+        assert self.test_inst.data.sizes['RO'] == bin_num
 
         return


### PR DESCRIPTION
# Description

The current usage of 'Dataset.dims' will soon be deprecated. The return type of `Dataset.dims` will be changed to return a set of dimension names in future, in order to be more consistent with `DataArray.dims`. This PR replaces the current uses of 'Dataset.dims' with 'Dataset.sizes'.

## Type of change

Maintenance

# How Has This Been Tested?
**Test Configuration**:
* Operating system: GitHub Actions Ubuntu, Windows, and MacOS
* Version number: Python 3.X


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
