### PR TITLE
MAINT: update pysat standards, testing for SPEC-0, operational env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,17 @@ jobs:
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
+          # SPEC-0 compliance settings
           - python-version: "3.10"
             numpy_ver: "1.24"
+            pandas_ver: "1.5.0"
+            scipy_ver: "1.10.0"
+            xarray_ver: "2022.9.0"
             os: ubuntu-latest
-            test_config: "NEP29"
-          - python-version: "3.6.8"
-            numpy_ver: "1.19.5"
+            test_config: "SPEC0"
+          # Operational compliance settings
+          - python-version: "3.9"
+            numpy_ver: "1.23.5"
             os: "ubuntu-20.04"
             test_config: "Ops"
 
@@ -37,15 +42,16 @@ jobs:
     - name: Install Operational dependencies
       if: ${{ matrix.test_config == 'Ops'}}
       run: |
-        pip install --no-cache-dir numpy==${{ matrix.numpy_ver }}
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
-        pip install .
+        pip install numpy==${{ matrix.numpy_ver }}
+        pip install --upgrade-strategy only-if-needed .[test]
 
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.test_config == 'NEP29'}}
+    - name: Install SPEC-0 dependencies
+      if: ${{ matrix.test_config == 'SPEC0'}}
       run: |
         pip install numpy==${{ matrix.numpy_ver }}
+        pip install pandas==${{ matrix.pandas_ver }}
+        pip install scipy==${{ matrix.scipy_ver }}
+        pip install xarray==${{ matrix.xarray_ver }}
         pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install standard dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             pandas_ver: "1.5.0"
             scipy_ver: "1.10.0"
             xarray_ver: "2022.9.0"
-            pysat_ver: "3.0.4"
+            pysat_ver: "3.1.0"
             os: ubuntu-latest
             test_config: "SPEC0"
           # Operational compliance settings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
             pandas_ver: "1.5.0"
             scipy_ver: "1.10.0"
             xarray_ver: "2022.9.0"
-            pysat_ver: "3.1.0"
+            pysat_ver: "3.2.1"
             os: ubuntu-latest
             test_config: "SPEC0"
           # Operational compliance settings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,12 +16,13 @@ jobs:
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
-          # SPEC-0 compliance settings
+          # SPEC-0 compliance settings w/ minimum supported pysat
           - python-version: "3.10"
             numpy_ver: "1.24"
             pandas_ver: "1.5.0"
             scipy_ver: "1.10.0"
             xarray_ver: "2022.9.0"
+            pysat_ver: "3.0.4"
             os: ubuntu-latest
             test_config: "SPEC0"
           # Operational compliance settings
@@ -52,6 +53,7 @@ jobs:
         pip install pandas==${{ matrix.pandas_ver }}
         pip install scipy==${{ matrix.scipy_ver }}
         pip install xarray==${{ matrix.xarray_ver }}
+        pip install pysat==${{ matrix.pysat_ver }}
         pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install standard dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.0.5] - 202X-XX-XX
+## [0.0.5] - 2024-11-30
 * Maintenance
   * Update GitHub Actions standards
   * Add compatibility for numpy version>=3.2.0
   * Update usage of 'Dataset.dims' to 'Dataset.sizes'
+  * Update compatibility with pysat 3.2.0
+  * Update operational environment
 
 ## [0.0.4] - 2023-08-11
 * Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [0.0.5] - 2024-11-30
+## [0.0.5] - 2024-XX-XX
 * Maintenance
-  * Update GitHub Actions standards
+  * Update GitHub Actions standards, including SPEC-0 tests
   * Add compatibility for numpy version>=3.2.0
   * Update usage of 'Dataset.dims' to 'Dataset.sizes'
   * Update compatibility with pysat 3.2.0
+  * Set minimum pysat version to 3.1.0
   * Update operational environment
 
 ## [0.0.4] - 2023-08-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * Update usage of 'Dataset.dims' to 'Dataset.sizes'
   * Update compatibility with pysat 3.2.0
   * Set minimum pysat version to 3.1.0
+  * Set minimum python version to 3.9
   * Update operational environment
 
 ## [0.0.4] - 2023-08-11

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python 3.7+.
 
 | Common modules | Community modules   |
 | -------------- | ------------------- |
-| netCDF4        | pysat>=3.1.0        |
+| netCDF4        | pysat>=3.2.1        |
 | numpy          |                     |
 | pandas         |                     |
 | requests       |                     |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Python 3.7+.
 
 | Common modules | Community modules   |
 | -------------- | ------------------- |
-| netCDF4        | pysat>=3.0.4,<3.2.0 |
+| netCDF4        | pysat>=3.1.0        |
 | numpy          |                     |
 | pandas         |                     |
 | requests       |                     |

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,7 +14,7 @@ Prerequisites
 
 pysatCDAAC uses common Python modules, as well as modules developed by
 and for the Space Physics community.  This module officially supports
-Python 3.6+ and pysat 3.0.4+.
+Python 3.9+ and pysat 3.1.0+.
 
  ================== ====================
  Common modules     Community modules

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Python 3.6+ and pysat 3.0.4+.
  ================== ====================
  Common modules     Community modules
  ================== ====================
-  netCDF4            pysat>=3.0.4,<3.2.0
+  netCDF4            pysat>=3.1.0
   numpy
   pandas
   requests

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,7 +19,7 @@ Python 3.9+ and pysat 3.1.0+.
  ================== ====================
  Common modules     Community modules
  ================== ====================
-  netCDF4            pysat>=3.1.0
+  netCDF4            pysat>=3.2.1
   numpy
   pandas
   requests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pandas",
-  "pysat >= 3.1.0",
+  "pysat >= 3.2.1",
   "requests",
   "xarray"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pysatCDAAC"
 version = "0.0.4"
 description = "pysat support for CDAAC Instruments"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "Jeff Klenzing, et al.", email = "pysat.developers@gmail.com"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pandas",
-  "pysat >= 3.0.4",
+  "pysat >= 3.1.0",
   "requests",
   "xarray"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.6",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows"
@@ -39,7 +39,7 @@ dependencies = [
   "netCDF4",
   "numpy",
   "pandas",
-  "pysat >= 3.0.4, <3.2.0",
+  "pysat >= 3.0.4",
   "requests",
   "xarray"
 ]

--- a/pysatCDAAC/__init__.py
+++ b/pysatCDAAC/__init__.py
@@ -16,9 +16,4 @@ import importlib
 from pysatCDAAC import instruments  # noqa F401
 
 # Set version
-try:
-    __version__ = importlib.metadata.version('pysatCDAAC')
-except AttributeError:
-    # Python 3.6 requires a different version
-    import importlib_metadata
-    __version__ = importlib_metadata.version('pysatCDAAC')
+__version__ = importlib.metadata.version('pysatCDAAC')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 netCDF4
 numpy
 pandas
-pysat>=3.1.0
+pysat>=3.2.1
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 netCDF4
 numpy
 pandas
-pysat>=3.0.3, <3.2.0
+pysat>=3.1.0
 requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[metadata]
-name = pysatCDAAC
-version = 0.0.4
-
 [flake8]
 max-line-length = 80
 ignore =


### PR DESCRIPTION
# Description

Addresses #51, #54

Updates multiple standards, including
- Test against new operation env standards (python 3.9, numpy 1.23.5)
- Remove duplicate metadata needed for python 3.6
- Set minimum supported python to 3.9
- Include SPEC-0 tests, with older versions of numpy, scipy, xarray, pandas, pysat

Because of internal changes at pysat, the minimum version is set to pysat 3.1.0 (released May 2023, ~18 months ago). Since this will still be an alpha release, full backwards compatibility to pysat 3.0 is not implemented. Tests for pysat<3.1.0 are failing for code that has been deprecated and removed (related to higher-order metadata).

In theory, the requirements.txt and test_requirements.txt can be removed as well (again, duplicate standards) since these are not used in the current tests or supported versions. Keeping them for the time being, will revisit at the next RC. Documented in #60.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via new GitHub Actions tests.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors
